### PR TITLE
Add Baseline Provider Verifications

### DIFF
--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -152,6 +152,8 @@ func TestMultipleSeedersOneLeecher(t *testing.T) {
 
 	utils.VerifyFileContent(t, utils.TestFileName, seederConfig1.DataDir, []string{leecherConfig1.DataDir})
 	utils.VerifyFileContent(t, utils.TestFileName, seederConfig2.DataDir, []string{leecherConfig1.DataDir})
+	utils.VerifyBaselineProvider(t, []*rbt.Torrent{seederTorrent1, seederTorrent2, leecherTorrent1}, []int{})
+	utils.VerifyBaselineProvider(t, []*rbt.Torrent{}, []int{4000})
 }
 
 
@@ -221,4 +223,6 @@ func TestOneSeederMultipleLeechers(t *testing.T) {
 
 	// Verify file content equality
 	utils.VerifyFileContent(t, utils.TestFileName, seederConfig.DataDir, []string{leecherConfig1.DataDir, leecherConfig2.DataDir, leecherConfig3.DataDir})
+	utils.VerifyBaselineProvider(t, []*rbt.Torrent{seederTorrent, leecherTorrent, leecherTorrent2, leecherTorrent3}, []int{})
+	utils.VerifyBaselineProvider(t, []*rbt.Torrent{}, []int{4000})
 }


### PR DESCRIPTION
Minor changes

Added the baseline provider verification for existing tests to confirm that the seeders and leechers do not know about the existence of the baseline provider since the baseline provider is not included in the tests.